### PR TITLE
Return metadata privileges for views and foreign tables

### DIFF
--- a/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java
+++ b/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java
@@ -3200,7 +3200,7 @@ public class RedshiftDatabaseMetaData implements DatabaseMetaData {
           + " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c, pg_catalog.pg_user u "
           + " WHERE c.relnamespace = n.oid "
           + " AND c.relowner = u.usesysid "
-          + " AND c.relkind IN ('r','p') ";
+          + " AND c.relkind IN ('r','p','v','m','f') ";
 
     sql += getCatalogFilterCondition(catalog);
     


### PR DESCRIPTION
## Description
Essentially the query to get the access privileges for table-like objects is missing some of the types. So we add views, materialized views, and foreign tables.

## Motivation and Context
Without the change, when you call `getTablePrivileges()` on views or foreign tables you'll get no results back.
Redshift experiences the same issue filed here https://github.com/pgjdbc/pgjdbc/issues/2048
and fixed here https://github.com/pgjdbc/pgjdbc/pull/2049 as part of release 42.2.19.

## Testing
Verified by creating views, granting users access to them, and verifying the JDBC metadata call now returns the proper list of users with privileges.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
