### PR TITLE
Feature addition: Enable setting the STS Endpoint from the SAML Assertion

### DIFF
--- a/src/main/java/com/amazon/redshift/plugin/SamlCredentialsProvider.java
+++ b/src/main/java/com/amazon/redshift/plugin/SamlCredentialsProvider.java
@@ -357,6 +357,14 @@ public abstract class SamlCredentialsProvider extends IdpCredentialsProvider imp
                 principal = entry.getValue();
             }
 
+            // Set STS Regional Endpoint from SAML Assertion
+            List<String> attributeValues = GetSAMLAttributeValues(xPath, doc,
+                    "https://redshift.amazon.com/SAML/Attributes/StsEndpointUrl");
+            if (!attributeValues.isEmpty() && m_stsEndpoint == null)
+            {
+                m_stsEndpoint = attributeValues.get(0);
+            }
+
             AssumeRoleWithSAMLRequest samlRequest = new AssumeRoleWithSAMLRequest();
             samlRequest.setSAMLAssertion(samlAssertion);
             samlRequest.setRoleArn(roleArn);


### PR DESCRIPTION
## Description
Added functionality in SamlCredentialsProvider.java to support setting the STS endpoint from a claim (StsEndpointUrl) in the SAML assertion.

## Motivation and Context
In a scenario where a regional STS endpoint is having availability issues, this change allows a central administrator to modify the STS endpoint in a single place in the IdP configuration to accelerate the recovery of access to RedShift clusters.  The regional endpoint can currently be changed using extended properties, but it requires every redshift user to modify their configuration.  This will reduce the overhead on redshift users and accelerate recovery time. The change does allow the redshift user to overwrite the endpoint passed in the SAML assertion using extended properties if desired.

## Testing
For testing, I rebuilt the driver with the updated code and manually ran through the following tests to ensure everything functioned as expected: 
* Passing in no claim
* Passing in the StsEndpointUrl claim
* Passing in the StsEndpointUrl claim with the StsEndpointUrl extended property set.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
- [X] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
