### PR TITLE
Introducing jdbc parameter to override Schema Pattern Type in getTables function.

### DIFF
--- a/src/main/java/com/amazon/redshift/RedshiftProperty.java
+++ b/src/main/java/com/amazon/redshift/RedshiftProperty.java
@@ -21,6 +21,13 @@ import java.util.Properties;
  * datasource setters.
  */
 public enum RedshiftProperty {
+  /**
+   * TODO: description
+   */
+  OVERRIDE_SCHEMA_PATTERN_TYPE(
+    "OverrideSchemaPatternType",
+    null,
+    "Override the type of query used in getTables calls"),
 
   /**
    * When using the V3 protocol the driver monitors changes in certain server configuration

--- a/src/main/java/com/amazon/redshift/RedshiftProperty.java
+++ b/src/main/java/com/amazon/redshift/RedshiftProperty.java
@@ -22,7 +22,8 @@ import java.util.Properties;
  */
 public enum RedshiftProperty {
   /**
-   * TODO: description
+   * Override Schema Pattern Type used in getTables()
+   * This is due to performance issues with svv_* redshift tables
    */
   OVERRIDE_SCHEMA_PATTERN_TYPE(
     "OverrideSchemaPatternType",

--- a/src/main/java/com/amazon/redshift/jdbc/RedshiftConnectionImpl.java
+++ b/src/main/java/com/amazon/redshift/jdbc/RedshiftConnectionImpl.java
@@ -150,6 +150,8 @@ public class RedshiftConnectionImpl implements BaseConnection {
   private boolean readOnly = false;
   // Filter out database objects for which the current user has no privileges granted from the DatabaseMetaData
   private boolean  hideUnprivilegedObjects ;
+  // Override getTables metadata type
+  private Integer overrideSchemaPatternType ;
   // Bind String to UNSPECIFIED or VARCHAR?
   private final boolean bindStringAsVarchar;
 
@@ -332,6 +334,8 @@ public class RedshiftConnectionImpl implements BaseConnection {
     this.databaseMetadataCurrentDbOnly = RedshiftProperty.DATABASE_METADATA_CURRENT_DB_ONLY.getBoolean(info);
 
     this.hideUnprivilegedObjects = RedshiftProperty.HIDE_UNPRIVILEGED_OBJECTS.getBoolean(info);
+
+    this.overrideSchemaPatternType = RedshiftProperty.OVERRIDE_SCHEMA_PATTERN_TYPE.getInteger(info);
 
     this.reWriteBatchedInsertsSize = RedshiftProperty.REWRITE_BATCHED_INSERTS_SIZE.getInt(info);
     
@@ -1352,6 +1356,10 @@ public class RedshiftConnectionImpl implements BaseConnection {
   
   public int getReWriteBatchedInsertsSize() {
     return this.reWriteBatchedInsertsSize;
+  }
+
+  public Integer getOverrideSchemaPatternType() {
+    return this.overrideSchemaPatternType;
   }
 
   public void setPrepareThreshold(int newThreshold) {

--- a/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java
+++ b/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
 public class RedshiftDatabaseMetaData implements DatabaseMetaData {
@@ -1573,7 +1574,8 @@ public class RedshiftDatabaseMetaData implements DatabaseMetaData {
     if (RedshiftLogger.isEnable())
     	connection.getLogger().logFunction(true, catalog, schemaPattern, tableNamePattern, types);
     
-    int schemaPatternType = getExtSchemaPatternMatch(schemaPattern);
+    
+    int schemaPatternType = Optional.ofNullable(connection.getOverrideSchemaPatternType()).orElse(getExtSchemaPatternMatch(schemaPattern));
 
     if (RedshiftLogger.isEnable())
     	connection.getLogger().logInfo("schemaPatternType = {0}", schemaPatternType);


### PR DESCRIPTION
https://github.com/aws/amazon-redshift-jdbc-driver/issues/64

With assistance/direction from @ngoble-phdata / https://github.com/ngoble-phdata

## Description
Due to performance issues with svv_* tables on larger clusters with a lot of external schemas, we need a way to prevent/override the type of Schema Pattern that is used when querying metadata from Redshift.

## Motivation and Context
https://github.com/aws/amazon-redshift-jdbc-driver/issues/64

## Testing
Built code, tested jar locally with SQLWorkbench with and without override parameter.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [X ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ X ] Local run of `mvn install` succeeds
- [ X ] My code follows the code style of this project
- [ X ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ X ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
