### PR TITLE
Enable TCP keep alive interval configuration

### DIFF
--- a/src/main/java/com/amazon/redshift/RedshiftProperty.java
+++ b/src/main/java/com/amazon/redshift/RedshiftProperty.java
@@ -843,6 +843,16 @@ public enum RedshiftProperty {
     "Enable or disable TCP keep-alive. The default is {@code true}."),
 
   /**
+   * Specifies the number of minutes of inactivity after which TCP keep alive messages will be transmitted.
+   * Only used when {@link TCP_KEEP_ALIVE} is {@code true}.
+   */
+  TCP_KEEP_ALIVE_MINUTES(
+    "tcpKeepAliveMinutes",
+    null,
+    "Specifies the number of minutes of inactivity after which TCP keep alive messages will be transmitted.",
+    false),
+
+  /**
    * Specifies the length to return for types of unknown length.
    */
   UNKNOWN_LENGTH(

--- a/src/main/java/com/amazon/redshift/core/v3/ConnectionFactoryImpl.java
+++ b/src/main/java/com/amazon/redshift/core/v3/ConnectionFactoryImpl.java
@@ -34,6 +34,7 @@ import com.amazon.redshift.util.ExtensibleDigest;
 import com.amazon.redshift.util.RedshiftException;
 import com.amazon.redshift.util.RedshiftState;
 import com.amazon.redshift.util.ServerErrorMessage;
+import jdk.net.ExtendedSocketOptions;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -121,8 +122,12 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 	
 	    // Enable TCP keep-alive probe if required.
 	    boolean requireTCPKeepAlive = RedshiftProperty.TCP_KEEP_ALIVE.getBoolean(info);
+        Integer keepAliveMinutes = RedshiftProperty.TCP_KEEP_ALIVE_MINUTES.getInteger(info);
 	    newStream.getSocket().setKeepAlive(requireTCPKeepAlive);
-	
+        if (requireTCPKeepAlive && keepAliveMinutes != null) {
+          newStream.getSocket().setOption(ExtendedSocketOptions.TCP_KEEPINTERVAL, keepAliveMinutes * 60);
+        }
+
 	    // Try to set SO_SNDBUF and SO_RECVBUF socket options, if requested.
 	    // If receiveBufferSize and send_buffer_size are set to a value greater
 	    // than 0, adjust. -1 means use the system default, 0 is ignored since not

--- a/src/main/java/com/amazon/redshift/core/v3/ConnectionFactoryImpl.java
+++ b/src/main/java/com/amazon/redshift/core/v3/ConnectionFactoryImpl.java
@@ -122,11 +122,12 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 	
 	    // Enable TCP keep-alive probe if required.
 	    boolean requireTCPKeepAlive = RedshiftProperty.TCP_KEEP_ALIVE.getBoolean(info);
-        Integer keepAliveMinutes = RedshiftProperty.TCP_KEEP_ALIVE_MINUTES.getInteger(info);
+	    Integer keepAliveMinutes = RedshiftProperty.TCP_KEEP_ALIVE_MINUTES.getInteger(info);
 	    newStream.getSocket().setKeepAlive(requireTCPKeepAlive);
-        if (requireTCPKeepAlive && keepAliveMinutes != null) {
-          newStream.getSocket().setOption(ExtendedSocketOptions.TCP_KEEPINTERVAL, keepAliveMinutes * 60);
-        }
+	      if (requireTCPKeepAlive && keepAliveMinutes != null) {
+	        newStream.getSocket().setOption(ExtendedSocketOptions.TCP_KEEPIDLE, keepAliveMinutes * 60);
+	        newStream.getSocket().setOption(ExtendedSocketOptions.TCP_KEEPINTERVAL, 1);
+	      }
 
 	    // Try to set SO_SNDBUF and SO_RECVBUF socket options, if requested.
 	    // If receiveBufferSize and send_buffer_size are set to a value greater

--- a/src/main/java/com/amazon/redshift/core/v3/ConnectionFactoryImpl.java
+++ b/src/main/java/com/amazon/redshift/core/v3/ConnectionFactoryImpl.java
@@ -124,10 +124,10 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 	    boolean requireTCPKeepAlive = RedshiftProperty.TCP_KEEP_ALIVE.getBoolean(info);
 	    Integer keepAliveMinutes = RedshiftProperty.TCP_KEEP_ALIVE_MINUTES.getInteger(info);
 	    newStream.getSocket().setKeepAlive(requireTCPKeepAlive);
-	      if (requireTCPKeepAlive && keepAliveMinutes != null) {
-	        newStream.getSocket().setOption(ExtendedSocketOptions.TCP_KEEPIDLE, keepAliveMinutes * 60);
-	        newStream.getSocket().setOption(ExtendedSocketOptions.TCP_KEEPINTERVAL, 1);
-	      }
+	    if (requireTCPKeepAlive && keepAliveMinutes != null) {
+	      newStream.getSocket().setOption(ExtendedSocketOptions.TCP_KEEPIDLE, keepAliveMinutes * 60);
+	      newStream.getSocket().setOption(ExtendedSocketOptions.TCP_KEEPINTERVAL, 1);
+	    }
 
 	    // Try to set SO_SNDBUF and SO_RECVBUF socket options, if requested.
 	    // If receiveBufferSize and send_buffer_size are set to a value greater


### PR DESCRIPTION
## Description

The Redshift configuration guide documents a `TCPKeepAliveMinutes` configuration [1] to control the socket keep alive interval. This PR implements support for this configuration, which appears to have been dropped in the 1.x to 2.x transition.

## Motivation and Context

The default keepalive interval of 2h on most operating systems is a frequent cause of dropped and hung connections, particularly when connecting to Redshift through proxy services or load balancers which may drop connections on a shorter timeout.

## Testing

I've manually tested via `strace -f -e trace=setsockopt` that this patch does yield `setsockopt(206, SOL_TCP, TCP_KEEPINTVL, [60], 4) = 0` for my application (when I set the connection property `tcpKeepAliveMinutes` to 1). I don't know of a way to unit test this functionality.

[1]: https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-install.html#configure-tcp-keepalives-jdbc20

## License

I confirm that this request can be released under the Apache 2 license.

