### PR TITLE
Fix `getColumns` for Late binding views

### DIFF
--- a/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java
+++ b/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java
@@ -2482,7 +2482,7 @@ public class RedshiftDatabaseMetaData implements DatabaseMetaData {
       result.append("WHEN 'timestamp without time zone' THEN 6 ");
       result.append("WHEN 'geometry' THEN NULL ");
       result.append("WHEN 'super' THEN NULL ");
-      result.append("WHEN 'numeric' THEN regexp_substr (columntype,'[0-9]+',charindex (',',columntype))::INTEGER ");      
+      result.append("WHEN 'numeric' THEN isnull(nullif(regexp_substr (columntype,'[0-9]+',charindex (',',columntype)),''),'0')::INTEGER ");
       result.append("WHEN 'varbyte' THEN NULL ");
       result.append("WHEN 'geography' THEN NULL ");
       result.append("ELSE 0 END AS DECIMAL_DIGITS, ");


### PR DESCRIPTION
... where column is a CASE numeric with null

If we have a late binding view defined as example view test_view, the JDBC driver will fail to obtain its schema through the standard JDBC method `DatabaseMetaData.getColumns`, with the following error: `ERROR: invalid input syntax for integer: ""`

Testcase:
```
CREATE OR REPLACE VIEW test_view AS
WITH test_data AS (SELECT 'value1' AS value UNION ALL SELECT 'value2' AS value)
SELECT CASE WHEN value = 'value1' THEN 123.45 END AS numeric_with_null
FROM test_data WITH NO SCHEMA BINDING;

SELECT * FROM test_view;
```

Initial issue is described in
https://github.com/aws/amazon-redshift-jdbc-driver/issues/45 Some specific field types in late-binding views cause the Redshift JDBC driver to throw an error on the `getColumns` call when fetching field metadata, but

2.1.0.5
Fix Github issue 45
4c24b47c5de633e8fd9bb1a2c1d414f740eb9909
seems fix some of these cases, but not all.
Specifically, a case statement that produces a mix of numeric and null values still results in an error.

maybe issue was reintroduced with
2.1.0.8
Fix numeric scale issue with Numeric data type of an external table e080dd6591e0ebca4e62c8c2767ac1de29b4fef2

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Do not parse not existing precision (as i other parts of existing code)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/aws/amazon-redshift-jdbc-driver/issues/45 was not fixed completely.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
CREATE OR REPLACE VIEW test_view AS
WITH test_data AS (SELECT 'value1' AS value UNION ALL SELECT 'value2' AS value)
SELECT CASE WHEN value = 'value1' THEN 123.45 END AS numeric_with_null
FROM test_data WITH NO SCHEMA BINDING;

SELECT * FROM test_view;
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

This section is not appropriate for this project.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
