### PR TITLE
fix null pointer exception when role based profile has no source_profile defined

### DIFF
--- a/src/main/java/com/amazon/redshift/core/PluginProfilesConfigFile.java
+++ b/src/main/java/com/amazon/redshift/core/PluginProfilesConfigFile.java
@@ -86,6 +86,9 @@ public class PluginProfilesConfigFile extends ProfilesConfigFile
         if (profile.isRoleBasedProfile())
         {
             String srcProfile = profile.getRoleSourceProfile();
+            if (StringUtils.isNullOrEmpty(srcProfile)) {
+                throw new SdkClientException("Unable to load credentials from role based profile [" + profileName + "]: Source profile name is not specified");
+            }
             CredentialsHolder srcCred = getCredentials(srcProfile);
             AWSCredentialsProvider provider = new AWSStaticCredentialsProvider(srcCred);
             credentials = assumeRole(profile, provider);


### PR DESCRIPTION
## Description
Fix #83 by testing if the source profile is properly set on role based profiles and throw an explicit exception if this is not the case.

## Motivation and Context
As explained in #83 an NullPointerException was thrown when configuration is not valid.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Reproduce the test case from #83.

## Screenshots (if appropriate)
Not relevant.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
