### PR TITLE
Increase HTTP server backlog size to 2

### DIFF
--- a/src/main/java/com/amazon/redshift/plugin/httpserver/Server.java
+++ b/src/main/java/com/amazon/redshift/plugin/httpserver/Server.java
@@ -90,7 +90,10 @@ public class Server
         this.m_ipAddress = InetAddress.getLoopbackAddress();
         this.m_socketFactory = ServerSocketFactory.getDefault();
         this.m_defaultSocketConfig = SocketConfig.custom()
-            .setBacklogSize(1)
+            // The backlog size needs to be at least 2 to avoid random `ERR_SOCKET_NOT_CONNECTED`
+            // errors in Google Chrome on macOS. It's caused by Chrome's "Preload pages" feature,
+            // which is enabled by default (located here: `chrome://settings/preloading`).
+            .setBacklogSize(2)
             .setSoKeepAlive(false)
             .setSoTimeout((int) waitTime.toMillis())
             .build();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR increases the backlog size of the ad hoc HTTP server from `1` to `2`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

I'm using `BrowserSamlCredentialsProvider` in [DataGrip](https://www.jetbrains.com/datagrip/) to connect to Redshift. I noticed that the login process would randomly fail in **Google Chrome on macOS** with `ERR_SOCKET_NOT_CONNECTED`:

![Screen Shot 2023-08-21 at 11 46 38 AM](https://github.com/aws/amazon-redshift-jdbc-driver/assets/24537029/f2053727-d556-418f-ba74-faf527181b04)

The error appears to be related to Chrome's "Preload pages" feature,
located at `chrome://settings/preloading`:

![Screen Shot 2023-08-21 at 12 38 37 PM](https://github.com/aws/amazon-redshift-jdbc-driver/assets/24537029/ee6405b2-1af7-4505-a983-b7b60b21abd1)

It causes Chrome to make an extra socket connection that frequently (but
not always) occupies the backlog size of `1` and causes the
subsequent `/redshift/` HTTP request to fail with
`ERR_SOCKET_NOT_CONNECTED`.

The error does not happen if preloading is disabled.

Since preloading is enabled by default, I thought it would be better to
increase the backlog size than to ask the user to disable preloading.

Increasing the backlog size to `2` seems to be enough to accommodate the
extra "preload" socket connection and allow the `/redshift/`
request to succeed.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I'm using macOS 12.6.6, running on Apple M1 Max
- Chrome is my default browser

I reproduced the error and verified the fix by running this code multiple times:

```java
import java.sql.Connection;
import java.sql.DriverManager;
import java.sql.SQLException;
import java.util.Properties;

class App {
    public static void main(String []args) throws SQLException, ClassNotFoundException {
        Class.forName("com.amazon.redshift.jdbc.Driver");
        Properties props = new Properties();
        props.setProperty("plugin_name", "com.amazon.redshift.plugin.BrowserSamlCredentialsProvider");
        props.setProperty("login_url", "<LOGIN_URL>");
        DriverManager.getConnection("jdbc:redshift:iam://<CLUSTER_NAME>:us-west-2/dev", props);
    }
}
```

I also tested a local build of the driver in DataGrip.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
