### PR TITLE
Support IAM role chaining for IAM authentication

### DIFF
--- a/src/main/java/com/amazon/redshift/plugin/AssumeRoleChainCredentialsProvider.java
+++ b/src/main/java/com/amazon/redshift/plugin/AssumeRoleChainCredentialsProvider.java
@@ -1,0 +1,134 @@
+package com.amazon.redshift.plugin;
+
+import com.amazon.redshift.IPlugin;
+import com.amazon.redshift.logger.LogLevel;
+import com.amazon.redshift.logger.RedshiftLogger;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+
+import static com.amazon.redshift.logger.LogLevel.INFO;
+
+/**
+ * Plugin to assume a role or a chain of roles first before using IAM authentication
+ */
+public class AssumeRoleChainCredentialsProvider implements IPlugin {
+
+    private static final String CACHE_KEY_PREFIX = "AssumeRole_";
+
+    /**
+     * default session name for role assumption if not provided
+     */
+    private static final String DEFAULT_SESSION_NAME = "assumeRoleIamAuthJDBC";
+
+    /**
+     * Connection property that sets the role chain. The property can either contain a single role ARN
+     * or a comma-separated list of role ARNs. The first role in the list is assumed first.
+     */
+    private String roleArn = null;
+
+    /**
+     *
+     */
+    private String sessionName = null;
+    private RedshiftLogger log = null;
+    private AWSCredentialsProvider credentialsProvider = null;
+
+
+    @Override
+    public void addParameter(String key, String value) {
+        if (key.equals("role_arn")) {
+            roleArn = value;
+        }
+
+        if (key.equals("session_name")) {
+            sessionName = value;
+        }
+    }
+
+    @Override
+    public void setLogger(RedshiftLogger log) {
+        this.log = log;
+    }
+
+    @Override
+    public String getPluginSpecificCacheKey() {
+        return CACHE_KEY_PREFIX + (roleArn != null ? roleArn : "") + (sessionName != null ? sessionName : "");
+    }
+
+    @Override
+    public void setGroupFederation(boolean groupFederation) {
+    }
+
+    @Override
+    public String getIdpToken() {
+        return null;
+    }
+
+    @Override
+    public String getCacheKey() {
+        return getPluginSpecificCacheKey();
+    }
+
+    @Override
+    public int getSubType() {
+        return 0;
+    }
+
+    @Override
+    public AWSCredentials getCredentials() {
+        return getCredentialsProvider().getCredentials();
+    }
+
+    protected AWSCredentialsProvider getCredentialsProvider() {
+        if (credentialsProvider == null) {
+            log(INFO, "Creating new credentials provider");
+            if (roleArn != null) {
+                log(INFO, "Found roleArn: %s and sessionName: %s", roleArn, getNonEmptySessionName());
+
+                String[] chainedRoleArns = roleArn.split(",");
+                credentialsProvider = createChainedAssumeRoleSessionCredentialsProvider(chainedRoleArns);
+            } else {
+                log(INFO, "No roleArn found, using " + DefaultAWSCredentialsProviderChain.class.getSimpleName());
+                credentialsProvider = new DefaultAWSCredentialsProviderChain();
+            }
+        }
+        return credentialsProvider;
+    }
+
+    protected AWSCredentialsProvider createChainedAssumeRoleSessionCredentialsProvider(String[] chainedRoleArns) {
+        AWSCredentialsProvider result = null;
+
+        for (String roleArn : chainedRoleArns) {
+            log(INFO, "Assuming role: %s", roleArn);
+
+            AWSSecurityTokenServiceClientBuilder stsClientBuilder = AWSSecurityTokenServiceClientBuilder.standard();
+            if (result != null) {
+                stsClientBuilder.withCredentials(result);
+            }
+
+            result = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, getNonEmptySessionName())
+                    .withStsClient(stsClientBuilder.build())
+                    .build();
+        }
+
+        return result;
+    }
+
+    protected String getNonEmptySessionName() {
+        return sessionName != null ? sessionName : DEFAULT_SESSION_NAME;
+    }
+
+    protected void log(LogLevel logLevel, String msg, Object... msgArgs) {
+        if (RedshiftLogger.isEnable()) {
+            log.log(logLevel, msg, msgArgs);
+        }
+    }
+
+    @Override
+    public void refresh() {
+        getCredentialsProvider().refresh();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The change allows client to configure one or more AWS IAM roles to be assumed before using IAM authentication to connect to a Redshift instance.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Sometimes 3rd-party clients like BI tools are not deployed in the same AWS account as the Redshift they should connect to. To allow them to use IAM authentication to connect to the Redshift instance, they need to assume the AWS account of the Redshift cluster first. The setup looks like this:

AWS account A:
* Redshift instance
* AWS IAM role `role_a` which allows to `getCredentials` for the Redshift instance and a trust relationship to `role_b`

AWS account B:
* AWS IAM role `role_b` which is allowed to assume `role_a`
* BI tool with assigned instance profile and `role_b`

With the new plugin, the connection to Redshift inside the BI tool can be configured to assume `role_a` first to make the IAM authentication work.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The plugin has been tested in the above setup.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
