### PR TITLE
fix: should wait for ringbuffer thread to finish before closing statement

### DIFF
--- a/src/main/java/com/amazon/redshift/jdbc/RedshiftStatementImpl.java
+++ b/src/main/java/com/amazon/redshift/jdbc/RedshiftStatementImpl.java
@@ -741,6 +741,15 @@ public class RedshiftStatementImpl implements Statement, BaseStatement {
    */
   public final void close() throws SQLException
   {
+    if (connection.getQueryExecutor().isRingBufferThreadRunning() &&
+          (!connection.getAutoCommit() || getMaxRows() == 0))
+      {
+        // Wait for current ring buffer thread to finish, if any.
+        // Shouldn't call from synchronized method, which can cause dead-lock.
+        // We don't want to wait for ring buffer to fetch all rows if setMaxRows() is set,
+        // or if autoCommit is set to true
+        connection.getQueryExecutor().waitForRingBufferThreadToFinish(false, false, true, null, null);
+    }
     if (RedshiftLogger.isEnable())
       connection.getLogger().logFunction(true);
 


### PR DESCRIPTION
## Description

If we do not wait for it, a subsequent call may have issues of  `ERROR: current transaction is aborted, commands ignored until end of transaction block`.

This check [existed until](https://github.com/filipelautert/amazon-redshift-jdbc-driver/commit/96bed2e0e503bcd1d44baffa361dcb3381106222) **2.1.0.21**, was replaced by method `resumeReadAndDiscardResults()` in **2.1.0.22** (this method  already presented issues), and some versions later the replacement was removed in https://github.com/filipelautert/amazon-redshift-jdbc-driver/commit/befa7de8437cb05519e1241f49807885be3a8c99 - so no checks for **ringbuffer** are done anymore when closing the connection. 


## Motivation and Context

Liquibase Redshift extension only works with driver versions until 2.1.0.21 . After that version it fails with the presented error message. 

## Testing

Run any Liquibase version (most recent is 4.30.0) using redshift integration ( https://github.com/liquibase/liquibase-redshift ):
* using driver version until 2.1.0.21, it works
* above that it fails

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
